### PR TITLE
Fix ISO set issue. Add a small delay when switching modes 

### DIFF
--- a/chdkptp/device.py
+++ b/chdkptp/device.py
@@ -84,7 +84,7 @@ class ChdkDevice(object):
     @property
     def mode(self):
         """ The current mode of the device, one of `record` or `play`. """
-        is_record, is_video, _ = self.lua_execute('return get_mode()')
+        is_record, is_video, _ = self.lua_execute('sleep(50); return get_mode()')
         return 'record' if is_record else 'play'
 
     def switch_mode(self, mode):
@@ -96,6 +96,7 @@ class ChdkDevice(object):
             return
         mode_num = int(mode == 'record')
         status, error = self.lua_execute("""
+            sleep(50)
             switch_mode_usb(%d)
             local i = 0
             while (get_mode() and 1 or 0) ~= %d and i < 300 do

--- a/chdkptp/util.py
+++ b/chdkptp/util.py
@@ -3,8 +3,8 @@ import os
 from chdkptp.lua import global_lua
 
 
-def iso_to_av96(iso):
-    return global_lua.globals.exposure.iso_to_av96(iso)
+def iso_to_sv96(iso):
+    return global_lua.globals.exposure.iso_to_sv96(iso)
 
 
 def shutter_to_tv96(shutter_speed):


### PR DESCRIPTION
The ISO fix is crucial for setting the values properly (otherwise quality suffers greatly). The delay helps prevent crashes.