### PR TITLE
parse ptp errors gracefully

### DIFF
--- a/chdkptp/__init__.py
+++ b/chdkptp/__init__.py
@@ -1,4 +1,5 @@
 from chdkptp.device import ChdkDevice, list_devices, DeviceInfo
+from chdkptp.lua import PTPError
 
 __version__ = "0.1.3"
-__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo']
+__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo', 'PTPError']

--- a/chdkptp/lua.py
+++ b/chdkptp/lua.py
@@ -11,13 +11,13 @@ logger = logging.getLogger('chdkptp.lua')
 
 class PTPError(Exception):
     def __init__(self, err_table):
-        msg = err_table.get('message')
-        errcode = err_table.get('ptp_rc')
+        msg = err_table['msg']
+        errcode = err_table['ptp_rc']
         super(PTPError, self).__init__(
             "{0} (ptp_code: {1})".format(msg or "Unknown error",
                                          errcode or 'unknown'))
         self.ptp_code = errcode
-        self.traceback = err_table.get('traceback')
+        self.traceback = err_table['traceback']
 
 
 class LuaContext(object):


### PR DESCRIPTION
First, chdkptp errors do not have a 'message' key, instead, it is 'msg'.
Then, for some reason the dictionary get() method throws an error:

> TypeError: 'NoneType' object is not callable

no matter if the key exists, or not. Not sure why that is so.

For example, using str(parse_table(err_table)), the structure of err_table is as follows:

> {'msg': 'I/O error', 'etype': 'ptp', 'traceback': '\nstack traceback:\n\t[C]: in function \'chdk_connection.execlua\'\n\t[C]: in function \'pcall\'\n\t...on2.7/site-packages/chdkptp/vendor/chdkptp/lua/chdku.lua:2084: in function \'execlua_pcall\'\n\t...on2.7/site-packages/chdkptp/vendor/chdkptp/lua/chdku.lua:1016: in function <...on2.7/site-packages/chdkptp/vendor/chdkptp/lua/chdku.lua:966>\n\t(...tail calls...)\n\t[string "<python>"]:4: in function <[string "<python>"]:1>\n\t[C]: in function \'pcall\'\n\t[string "<python>"]:1: in main chunk', 'ptp_rc': 767}

then the following error is thrown when using get() (no matter which key, just for example here is ptp_rc):

>   File "/Users/blah/Books/software/pi-scan/env/lib/python2.7/site-packages/chdkptp/lua.py", line 15, in __init__
>     errcode = err_table.get('ptp_rc')
> TypeError: 'NoneType' object is not callable

but using err_table['ptp_rc'], it will correctly get that key.

Not sure why that happens, but the simple fix is to use brackets. Yes it will throw if the key doesn't exists, but currently it is throwing in all cases, so at the very least, it is better than the current situation ;)