### PR TITLE
Upgrade to latest chdkptp and update chdkptp_module.diff to build libraries

### DIFF
--- a/chdkptp/__init__.py
+++ b/chdkptp/__init__.py
@@ -1,4 +1,5 @@
 from chdkptp.device import ChdkDevice, list_devices, DeviceInfo
+from chdkptp.lua import PTPError
 
 __version__ = "0.1.3"
-__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo']
+__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo', 'PTPError']

--- a/chdkptp/lua.py
+++ b/chdkptp/lua.py
@@ -11,13 +11,13 @@ logger = logging.getLogger('chdkptp.lua')
 
 class PTPError(Exception):
     def __init__(self, err_table):
-        msg = err_table.get('message')
-        errcode = err_table.get('ptp_rc')
+        msg = err_table['msg']
+        errcode = err_table['ptp_rc']
         super(PTPError, self).__init__(
             "{0} (ptp_code: {1})".format(msg or "Unknown error",
                                          errcode or 'unknown'))
         self.ptp_code = errcode
-        self.traceback = err_table.get('traceback')
+        self.traceback = err_table['traceback']
 
 
 class LuaContext(object):

--- a/chdkptp_module.diff
+++ b/chdkptp_module.diff
@@ -56,14 +56,14 @@ index de0662f..7535c3e 100644
  	uninit_gui_libs(L);
  	lua_close(L);
 diff --git a/include.mk b/include.mk
-index dbf51ca..7d0b713 100644
+index dbf51ca..2e537ae 100644
 --- a/include.mk
 +++ b/include.mk
 @@ -9,6 +9,7 @@ ifeq ($(HOSTPLATFORM),MINGW)
  OSTYPE=Windows
  EXE=.exe
  DLL=.dll
-+#LIB=.dll
++LIB=.dll
  # Note may be freetype or freetype6 depending on CD version, zlib requried for 5.5 and later
  CD_FREETYPE_LIB=freetype6 z
  #CD_FREETYPE_LIB=freetype z
@@ -71,13 +71,21 @@ index dbf51ca..7d0b713 100644
  OSTYPE=Linux
  EXE=
  DLL=.so
-+#LIB=.so
++LIB=.so
  CD_FREETYPE_LIB=freetype z
  endif
  ifeq ($(HOSTPLATFORM),Darwin)
-@@ -32,7 +34,7 @@ endif
+@@ -24,6 +26,7 @@ OSTYPE=Darwin
+ EXE=
+ # TODO .dylib? only used for signal
+ DLL=.so
++LIB=.so
+ # TODO?
+ CD_FREETYPE_LIB=freetype z
+ endif
+@@ -32,7 +35,7 @@ endif
  EXE_EXTRA=
- 
+
  CC=gcc
 -CFLAGS=-DCHDKPTP_OSTYPE=\"$(OSTYPE)\" -Wall
 +CFLAGS=-DCHDKPTP_OSTYPE=\"$(OSTYPE)\" -Wall -fPIC -g

--- a/chdkptp_module.diff
+++ b/chdkptp_module.diff
@@ -1,9 +1,9 @@
 diff --git a/Makefile b/Makefile
-index cc446d3..5244703 100644
+index 92ab23f..83d70c4 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -113,14 +113,19 @@ LDFLAGS+=$(LIB_PATHS) $(patsubst %,-l%,$(LINK_LIBS) $(SYS_LIBS))
- SUBDIRS=lfs
+@@ -128,14 +128,19 @@ SUBDIRS+=lua-signal
+ endif
  
  CHDKPTP_EXE=chdkptp$(EXE_EXTRA)$(EXE)
 +CHDKPTP_LIB=chdkptp$(EXE_EXTRA)$(LIB)
@@ -24,10 +24,10 @@ index cc446d3..5244703 100644
  	$(CC) -o $@ lfs/lfs.o $^ $(LDFLAGS)
  
 diff --git a/chdkptp.c b/chdkptp.c
-index 954d27c..36a259b 100644
+index de0662f..7535c3e 100644
 --- a/chdkptp.c
 +++ b/chdkptp.c
-@@ -2160,7 +2160,11 @@ static const luaL_Reg lua_errlib[] = {
+@@ -2197,7 +2197,11 @@ static const luaL_Reg lua_errlib[] = {
  };
  
  
@@ -40,7 +40,7 @@ index 954d27c..36a259b 100644
  	/* set up meta table for error object */
  	luaL_newmetatable(L,CHDK_API_ERROR_META);
  	lua_pushcfunction(L,api_error_tostring);
-@@ -2229,13 +2233,9 @@ int main(int argc, char ** argv)
+@@ -2266,13 +2270,9 @@ int main(int argc, char ** argv)
  	g_argv = argv;
  	/* register signal handlers */
  //	signal(SIGINT, ptpcam_siginthandler);
@@ -52,30 +52,30 @@ index 954d27c..36a259b 100644
 -	luaopen_rawimg(L);	
 -	chdkptp_registerlibs(L);
 +	luaopen_chdkptp(L);
- 	exec_lua_string(L,"require('main')");
+ 	int r=exec_lua_string(L,"require('main')");
  	uninit_gui_libs(L);
  	lua_close(L);
 diff --git a/include.mk b/include.mk
-index 954f855..7080d8a 100644
+index dbf51ca..7d0b713 100644
 --- a/include.mk
 +++ b/include.mk
-@@ -7,6 +7,7 @@ HOSTPLATFORM:=$(patsubst MINGW%,MINGW,$(shell uname -s))
- ifeq ($(HOSTPLATFORM),MINGW)
+@@ -9,6 +9,7 @@ ifeq ($(HOSTPLATFORM),MINGW)
  OSTYPE=Windows
  EXE=.exe
-+LIB=.dll
- # Note may be freetype or freetype6 depending on your CD version, zlib requried for 5.5 and later
+ DLL=.dll
++#LIB=.dll
+ # Note may be freetype or freetype6 depending on CD version, zlib requried for 5.5 and later
  CD_FREETYPE_LIB=freetype6 z
  #CD_FREETYPE_LIB=freetype z
-@@ -14,6 +15,7 @@ else
- ifeq ($(HOSTPLATFORM),Linux)
+@@ -17,6 +18,7 @@ ifeq ($(HOSTPLATFORM),Linux)
  OSTYPE=Linux
- EXE= 
-+LIB=.so
+ EXE=
+ DLL=.so
++#LIB=.so
  CD_FREETYPE_LIB=freetype z
  endif
- endif
-@@ -22,7 +24,7 @@ endif
+ ifeq ($(HOSTPLATFORM),Darwin)
+@@ -32,7 +34,7 @@ endif
  EXE_EXTRA=
  
  CC=gcc


### PR DESCRIPTION
Pretty self explanatory. See the commit comments for details. The upgrade to latest chdkptp is straightforward, just some things moved around in the files modified by chdkptp_modue.diff so that is reflected there.

Then the libraries needed to be built in os x, etc. as reflected in this issue, so this pull request should close that: https://github.com/jbaiter/chdkptp.py/issues/8