### PR TITLE
Clean up build process & update chdkptp to r962

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/chdkptp"]
-	path = chdkptp/vendor/chdkptp
-	url = https://github.com/svn2github/chdkptp.git

--- a/chdkptp/vendor/.gitignore
+++ b/chdkptp/vendor/.gitignore
@@ -1,0 +1,1 @@
+chdkptp/*

--- a/chdkptp_module.diff
+++ b/chdkptp_module.diff
@@ -1,9 +1,8 @@
 diff --git a/Makefile b/Makefile
-index cc446d3..5244703 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -113,14 +113,19 @@ LDFLAGS+=$(LIB_PATHS) $(patsubst %,-l%,$(LINK_LIBS) $(SYS_LIBS))
- SUBDIRS=lfs
+@@ -128,14 +128,19 @@ SUBDIRS+=lua-signal
+ endif
  
  CHDKPTP_EXE=chdkptp$(EXE_EXTRA)$(EXE)
 +CHDKPTP_LIB=chdkptp$(EXE_EXTRA)$(LIB)
@@ -24,15 +23,15 @@ index cc446d3..5244703 100644
  	$(CC) -o $@ lfs/lfs.o $^ $(LDFLAGS)
  
 diff --git a/chdkptp.c b/chdkptp.c
-index 954d27c..36a259b 100644
 --- a/chdkptp.c
 +++ b/chdkptp.c
-@@ -2160,7 +2160,11 @@ static const luaL_Reg lua_errlib[] = {
+@@ -2579,7 +2579,12 @@ static const luaL_Reg lua_errlib[] = {
  };
  
  
 -static int chdkptp_registerlibs(lua_State *L) {
 +int luaopen_chdkptp(lua_State *L) {
++	init_timing();
 +	usb_init();
 +	luaopen_lfs(L);
 +	luaopen_lbuf(L);
@@ -40,10 +39,11 @@ index 954d27c..36a259b 100644
  	/* set up meta table for error object */
  	luaL_newmetatable(L,CHDK_API_ERROR_META);
  	lua_pushcfunction(L,api_error_tostring);
-@@ -2229,13 +2233,9 @@ int main(int argc, char ** argv)
+@@ -2648,14 +2653,9 @@ int main(int argc, char ** argv)
  	g_argv = argv;
  	/* register signal handlers */
  //	signal(SIGINT, ptpcam_siginthandler);
+-	init_timing();
 -	usb_init();
  	lua_State *L = luaL_newstate();
  	luaL_openlibs(L);
@@ -52,32 +52,31 @@ index 954d27c..36a259b 100644
 -	luaopen_rawimg(L);	
 -	chdkptp_registerlibs(L);
 +	luaopen_chdkptp(L);
- 	exec_lua_string(L,"require('main')");
+ 	int r=exec_lua_string(L,"require('main')");
  	uninit_gui_libs(L);
  	lua_close(L);
 diff --git a/include.mk b/include.mk
-index 954f855..7080d8a 100644
 --- a/include.mk
 +++ b/include.mk
-@@ -7,6 +7,7 @@ HOSTPLATFORM:=$(patsubst MINGW%,MINGW,$(shell uname -s))
- ifeq ($(HOSTPLATFORM),MINGW)
+@@ -9,6 +9,7 @@ ifeq ($(HOSTPLATFORM),MINGW)
  OSTYPE=Windows
  EXE=.exe
+ DLL=.dll
 +LIB=.dll
- # Note may be freetype or freetype6 depending on your CD version, zlib requried for 5.5 and later
+ # Note may be freetype or freetype6 depending on CD version, zlib requried for 5.5 and later
  CD_FREETYPE_LIB=freetype6 z
  #CD_FREETYPE_LIB=freetype z
-@@ -14,6 +15,7 @@ else
- ifeq ($(HOSTPLATFORM),Linux)
+@@ -17,6 +18,7 @@ ifeq ($(HOSTPLATFORM),Linux)
  OSTYPE=Linux
- EXE= 
+ EXE=
+ DLL=.so
 +LIB=.so
  CD_FREETYPE_LIB=freetype z
  endif
  endif
-@@ -22,7 +24,7 @@ endif
+@@ -32,7 +35,7 @@ endif
  EXE_EXTRA=
- 
+
  CC=gcc
 -CFLAGS=-DCHDKPTP_OSTYPE=\"$(OSTYPE)\" -Wall
 +CFLAGS=-DCHDKPTP_OSTYPE=\"$(OSTYPE)\" -Wall -fPIC -g

--- a/chdkptp_module.diff
+++ b/chdkptp_module.diff
@@ -83,3 +83,14 @@ diff --git a/include.mk b/include.mk
  LDFLAGS=
  #LD=ld
  
+--- a/misc/setup-ext-libs.bash
++++ b/misc/setup-ext-libs.bash
+@@ -534,7 +534,7 @@
+ build_lua() {
+ 	info_msg "building Lua"
+ 	change_dir "$SRC_DIR/lua-$LUA_VER"
+-	do_make build-lua.log "$LUA_TARGET"
++	do_make build-lua.log "$LUA_TARGET" MYCFLAGS=-fPIC
+ }
+ 
+ copy_built_lua() {

--- a/get_chdkptp.py
+++ b/get_chdkptp.py
@@ -1,6 +1,8 @@
 import os
 import io
+import sys
 import shutil
+import subprocess as sub
 from zipfile import ZipFile
 
 try:
@@ -25,3 +27,19 @@ def get_chdkptp_source(outdir):
     with ZipFile(data, 'r') as z:
         os.mkdir(outdir)
         z.extractall(path=outdir)
+
+
+def apply_patches(srcdir, patchfile):
+    sub.check_call(['patch', '-d', srcdir, '-i', patchfile, '-p', '1'])
+
+
+def build_static_lua(srcdir):
+    orig_path = os.getcwd()
+    misc_path = os.path.join(srcdir, 'misc')
+    os.chdir(misc_path)
+    cmd = ['bash', 'setup-ext-libs.bash', '-nogui']
+    p = sub.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    p.communicate()
+    if p.returncode != 0:
+        raise RuntimeError("Error building static Lua")
+    os.chdir(orig_path)

--- a/get_chdkptp.py
+++ b/get_chdkptp.py
@@ -1,0 +1,29 @@
+import os
+import io
+import shutil
+from zipfile import ZipFile
+
+try:
+    import urllib.request
+    from urllib.request import urlopen # Python 3.x
+except ImportError:
+    from urllib2 import urlopen # Python 2
+
+
+REVISION = 664  # Version used in original submodule
+SVN_URL_BASE = "https://app.assembla.com/spaces/chdkptp/subversion/source/"
+SVN_URL = SVN_URL_BASE + "{0}/trunk?_format=zip&format=html".format(REVISION)
+
+chdkptp_srcdir = os.path.join('chdkptp', 'vendor', 'chdkptp')
+
+
+def get_chdkptp_source(outdir):
+
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+
+    dl = urlopen(SVN_URL)
+    data = io.BytesIO(dl.read())
+    with ZipFile(data, 'r') as z:
+        os.mkdir(outdir)
+        z.extractall(path=outdir)

--- a/get_chdkptp.py
+++ b/get_chdkptp.py
@@ -10,11 +10,9 @@ except ImportError:
     from urllib2 import urlopen # Python 2
 
 
-REVISION = 664  # Version used in original submodule
+REVISION = 962  # Latest binary release
 SVN_URL_BASE = "https://app.assembla.com/spaces/chdkptp/subversion/source/"
 SVN_URL = SVN_URL_BASE + "{0}/trunk?_format=zip&format=html".format(REVISION)
-
-chdkptp_srcdir = os.path.join('chdkptp', 'vendor', 'chdkptp')
 
 
 def get_chdkptp_source(outdir):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import subprocess
 from setuptools.command.install import install as InstallCommand
 from setuptools import setup
 
+from get_chdkptp import get_chdkptp_source
+
 CHDKPTP_PATH = os.path.abspath(os.path.join('.', 'chdkptp', 'vendor',
                                             'chdkptp'))
 CHDKPTP_PATCH = os.path.abspath(os.path.join('.', 'chdkptp_module.diff'))
@@ -17,6 +19,9 @@ class CustomInstall(InstallCommand):
                    os.path.join(CHDKPTP_PATH, 'config.mk'))
         subprocess.check_call(['make', '-C', CHDKPTP_PATH])
         InstallCommand.run(self)
+
+
+get_chdkptp_source(CHDKPTP_PATH)
 
 setup(
     name='chdkptp.py',

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,15 @@ import subprocess
 from setuptools.command.install import install as InstallCommand
 from setuptools import setup
 
-from get_chdkptp import get_chdkptp_source
+from get_chdkptp import get_chdkptp_source, apply_patches, build_static_lua
 
-CHDKPTP_PATH = os.path.abspath(os.path.join('.', 'chdkptp', 'vendor',
-                                            'chdkptp'))
-CHDKPTP_PATCH = os.path.abspath(os.path.join('.', 'chdkptp_module.diff'))
+PKG_ROOT = os.path.dirname(os.path.abspath(__file__))
+CHDKPTP_PATH = os.path.join(PKG_ROOT, 'chdkptp', 'vendor', 'chdkptp')
+CHDKPTP_PATCH = os.path.join(PKG_ROOT, 'chdkptp_module.diff')
 
 
 class CustomInstall(InstallCommand):
     def run(self):
-        subprocess.check_call(['patch', '-d', CHDKPTP_PATH, '-i',
-                               CHDKPTP_PATCH, '-p', '1'])
         os.symlink(os.path.join(CHDKPTP_PATH, 'config-sample-linux.mk'),
                    os.path.join(CHDKPTP_PATH, 'config.mk'))
         subprocess.check_call(['make', '-C', CHDKPTP_PATH])
@@ -22,6 +20,8 @@ class CustomInstall(InstallCommand):
 
 
 get_chdkptp_source(CHDKPTP_PATH)
+apply_patches(CHDKPTP_PATH, CHDKPTP_PATCH)
+build_static_lua(CHDKPTP_PATH)
 
 setup(
     name='chdkptp.py',


### PR DESCRIPTION
This PR cleans up the overall chdkptp.so build process and updates the included chdkptp revision to r962, which matches the latest official binaries from the project.

First, this removes the chdkptp git submodule (which is stuck on an ancient version due to the closure of svn2github) and replaces it with a python script that grabs and unarchives a Zip of the source code straight from the project's SVN repo. This removes the need for SVN or submodules entirely and should make the process of updating the chdkptp revision much easier in the future.

Next, this updates the bundled chdkptp to r962 and updates the patchfile accordingly. 962 was used instead of the latest release to minimize the likelihood of breaking things while still using a more modern version.

Finally, to simplify the build process and remove the build requirement of Lua 5.2 or 5.3 (not available on current versions of Fedora and likely other distros as well), this PR uses chdkptp's own `setup-ext-libs.bash` script to download, build, and link to a static version of Lua 5.2 when building chdkptp. Making this work also requires modifying the Lua build script to compile with `-fPIC` enabled, since we're linking to it from a shared library instead of a standard binary like usual.